### PR TITLE
CQHTTP推送支持HTTPS

### DIFF
--- a/alert/notifiers/cqhttp.py
+++ b/alert/notifiers/cqhttp.py
@@ -11,19 +11,25 @@ class Cqhttp(Base):
 
     def send(self, text, status, desp):
         if config.CQHTTP_MESSAGE_TYPE == "group":
-            url = f'http://{config.CQHTTP_IP}:{config.CQHTTP_PORT}/send_group_msg'
+            if 'https://' in config.CQHTTP_IP or 'http://' in config.CQHTTP_IP :
+                url = f'{config.CQHTTP_IP}:{config.CQHTTP_PORT}/send_group_msg'
+            else :
+                url = f'http://{config.CQHTTP_IP}:{config.CQHTTP_PORT}/send_group_msg'
             header = {'Authorization': 'Bearer ' + config.CQHTTP_TOKEN}
             data = {
                 "group_id": config.CQHTTP_SEND_ID,
-                'message': f'{text} {status}\n\n{desp}'
+                "message": f'{text} {status}\n\n{desp}'
             }
 
         elif config.CQHTTP_MESSAGE_TYPE == "private":
-            url = f'http://{config.CQHTTP_IP}:{config.CQHTTP_PORT}/send_private_msg'
+            if 'https://' in config.CQHTTP_IP or 'http://' in config.CQHTTP_IP :
+                url = f'{config.CQHTTP_IP}:{config.CQHTTP_PORT}/send_private_msg'
+            else :
+                url = f'http://{config.CQHTTP_IP}:{config.CQHTTP_PORT}/send_private_msg'
             header = {'Authorization': 'Bearer ' + config.CQHTTP_TOKEN}
             data = {
                 "user_id": config.CQHTTP_SEND_ID,
-                'message': f'{text} {status}\n\n{desp}'
+                "message": f'{text} {status}\n\n{desp}'
             }
 
         return self.push('post', url, headers=header, data=data)


### PR DESCRIPTION
配置文件 CQHTTP_IP 字段可添加协议头以支持 HTTPS，不包含协议头则默认使用 HTTP 协议。